### PR TITLE
Fix failing test envs and test across supported nokogiri versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,25 @@
+dist: trusty
 language: ruby
 script: bundle exec rake
-rvm:
-  # 2.1, not 2.1.0 until fixed https://github.com/travis-ci/travis-ci/issues/2220
-  - 2.1
-  - 2.0.0
-  - 1.9.3
-  - 1.9.2
-  - jruby
-  - "rbx-2"
 matrix:
-  allow_failures:
-    - rvm: rbx-2
-    - rvm: 2.1
+  include:
+    - rvm: 2.6.3
+      gemfiles: gemfiles/nokogiri_1.10.4.gemfile
+    - rvm: 2.5.5
+      gemfiles: gemfiles/nokogiri_1.10.4.gemfile
+    - rvm: 2.3.8
+      gemfiles: gemfiles/nokogiri_1.10.4.gemfile
+    - rvm: 2.2.10
+      gemfiles: gemfiles/nokogiri_1.5.0.gemfile
+    - rvm: 2.1.10
+      gemfiles: gemfiles/nokogiri_1.5.0.gemfile
+    - rvm: 2.0.0
+      gemfiles: gemfiles/nokogiri_1.5.0.gemfile
+    - rvm: 1.9.3
+      gemfiles: gemfiles/nokogiri_1.5.0.gemfile
+    - rvm: 1.9.2
+      gemfiles: gemfiles/nokogiri_1.5.0.gemfile
+    - rvm: jruby-head
+      gemfiles: gemfiles/nokogiri_1.10.4.gemfile
+
   fast_finish: true

--- a/gemfiles/nokogiri_1.10.4.gemfile
+++ b/gemfiles/nokogiri_1.10.4.gemfile
@@ -5,9 +5,11 @@ gem 'pathological' # adds '.' to $LOAD_PATH per Pathfile
 gem 'rake'
 gem 'test-unit'
 
+gem 'nokogiri', '=1.10.4'
+
 group :test do
   # alternative runners for MiniTest, both colorful and informative.
   gem 'turn', :require => false
 end
 
-gemspec
+gemspec :path => "../"

--- a/gemfiles/nokogiri_1.5.0.gemfile
+++ b/gemfiles/nokogiri_1.5.0.gemfile
@@ -5,9 +5,11 @@ gem 'pathological' # adds '.' to $LOAD_PATH per Pathfile
 gem 'rake'
 gem 'test-unit'
 
+gem 'nokogiri', '=1.5.0'
+
 group :test do
   # alternative runners for MiniTest, both colorful and informative.
   gem 'turn', :require => false
 end
 
-gemspec
+gemspec :path => "../"

--- a/test/vast3_inline_ad_test.rb
+++ b/test/vast3_inline_ad_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class InlineAdTest < Test::Unit::TestCase
+class Vast3InlineAdTest < Test::Unit::TestCase
 
   def test_ad_should_know_attributes
     document_file = example_file('vast3_inline.xml')


### PR DESCRIPTION
**.travis.yml**
Added "dist: trusty". Travis will run this repo's CI on an Ubuntu Trusty 14.04 VM. This was done to maintain testing for ruby-1.9.2. Newer travis VM's don't support that ruby version.
Added new ruby versions: 2.1.10, 2.2.10, 2.3.8, 2.5.5 and 2.6.3
Had to remove testing to rbx-2. That package is not available on ubuntu trusty.
Changed the matrix exclude to a matrix include. This tests each ruby version with a specific nokogiri version.

**Gemfile**
Moved gemspec to the bottom of the file. This was done for the gemfiles/*. The versions in the gemfiles take precedence over the gemspec.
Explicitly add gem install for test-unit. In ruby 2.2, test-unit was removed from the core libraries.

**gemfiles/nokogiri_1.10.4.gemfile**
**gemfiles/nokogiri_1.5.0.gemfile**
Created gemfiles to test the oldest & newest version of nokogiri that works with vast.

**test/vast3_inline_ad_test.rb**
This file previously contained a test redefinition. Both test/inline_ad_test.rb and test/vast3_inline_ad_test.rb define a InlineAdTest class with a test_ad_should_know_attributes function. To solve this problem I renamed the class.