### PR TITLE
Formalize vast release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Vast v3.0 support [@@owen-admedo](https://github.com/@owen-admedo)
+- add MIT license [@bf4](https://github.com/bf4).
+- Travis ci automated testing [@careyrp](https://github.com/careyrp).
+### Changed
+- Supported nokogiri min version from 1.5.5 to 1.5.0 [@dolzenko](https://github.com/dolzenko).
+- Supported nokogiri max version from 1.6.0 to 2.0.0 [@dolzenko](https://github.com/dolzenko).
+
+## [1.0.4] - 2017-06-20
+### Added
+- dependency on pathological [@rui](https://github.com/ruiyang2012)
+### Changed
+- Support nokogiri min version from 1.4.3 to 1.5.5 [@rui](https://github.com/ruiyang2012)
+- Support nokogiri max version from 1.5.0 to 1.6.0 [@rui](https://github.com/ruiyang2012)
+- Replace optional gem redgreen with turn [@rui](https://github.com/ruiyang2012)
+
+## [1.0.3] - 2011-06-06
+### Changed
+- fix issue with URLs surounded by whitespace [@mdialog](https://github.com/mdialog)
+- add testing for whitespace issue [@aarongough](https://github.com/aarongough)
+### Removed
+- bundle config from source control [@chrisdinn](https://github.com/chrisdinn)
+
+## [1.0] - 2010-08-24
+### Added
+- femspec for Vast [@chrisdinn](https://github.com/chrisdinn)
+- class level documentation [@chrisdinn](https://github.com/chrisdinn)
+### Changed
+- README.md to README.rdoc [@chrisdinn](https://github.com/chrisdinn)
+
+## [0.2] - 2010-08-23
+### Added
+- initial release of Vast [@chrisdinn](https://github.com/chrisdinn)

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,5 @@
 source "https://rubygems.org"
 
-# Used in Rakefile
-gem 'pathological' # adds '.' to $LOAD_PATH per Pathfile
-gem 'rake'
-gem 'test-unit'
-
 group :test do
   # alternative runners for MiniTest, both colorful and informative.
   gem 'turn', :require => false

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
-= VAST
+= VAST {<img src="https://travis-ci.org/chrisdinn/vast.svg?branch=master" alt="Build Status" />}[https://travis-ci.org/chrisdinn/vast]
 
-A library for parsing Digital Video Ad Serving Template (VAST) 2.0 XML documents, as outlined by the Interactive Advertising Bureau at
+A library for parsing Digital Video Ad Serving Template (VAST) 2.0 and 3.0 XML documents, as outlined by the Interactive Advertising Bureau at
 http://www.iab.net/iab_products_and_industry_services/508676/digitalvideo/vast. VAST outlines a standard document format for communication between digital video players and ad servers, including support for
 multiple forms of creative and tracking support that conforms to the latest IAB standards.
 
@@ -49,6 +49,50 @@ Please, file an issue.
 * Commit, do not mess with rakefile, version, or history.
   (if you want to have your own version, that is fine but bump version in a commit by itself I can ignore when I pull)
 * Send me a pull request. Bonus points for topic branches.
+
+== Release Instructions
+
+Install project development dependencies. The release process will use gem-release for version management.
+
+  bundle install
+
+Checkout the master branch; never release changes that haven't been merged to master.
+
+  git checkout master
+
+Create a release branch. Release branch names should match the pattern "v[0-9]+\.[0-9]+\.[0-9]+".
+
+  git checkout v1.0.5
+
+Bump the project version. By default the bump command will increment the patch version in the lib/vast/version.rb file, and commit the git change.
+
+  gem bump [patch|minor|major] --branch
+
+Modify the CHANGELOG.md file. Add the new version to the top of the file, and document all major changes.
+
+When done commit the changelog.
+
+  export BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  git add CHANGELOG.md
+  git commit -m "CHANGELOG ${BRANCH}"
+
+Push your release branch to github.com
+
+  git push origin -u $BRANCH
+
+Open a new pull request from your branch to github.com:chrisdinn/vast@master
+
+Only a github user with write access to https://github.com/chrisdinn/vast can perform the remaining steps of the release.
+
+Review and merge the pull request to github.com:chrisdinn/vast@master
+
+Check Travis CI testing passed on the merge to master before continuing.
+
+Tag the release and push to rubygems.org using gem-release.
+
+  git checkout master
+  git pull origin
+  gem release --key $RUBYGEMS_API_KEY --tag --push
 
 == Copyright
 

--- a/gemfiles/nokogiri_1.10.4.gemfile
+++ b/gemfiles/nokogiri_1.10.4.gemfile
@@ -1,10 +1,5 @@
 source "https://rubygems.org"
 
-# Used in Rakefile
-gem 'pathological' # adds '.' to $LOAD_PATH per Pathfile
-gem 'rake'
-gem 'test-unit'
-
 gem 'nokogiri', '=1.10.4'
 
 group :test do

--- a/gemfiles/nokogiri_1.5.0.gemfile
+++ b/gemfiles/nokogiri_1.5.0.gemfile
@@ -1,10 +1,5 @@
 source "https://rubygems.org"
 
-# Used in Rakefile
-gem 'pathological' # adds '.' to $LOAD_PATH per Pathfile
-gem 'rake'
-gem 'test-unit'
-
 gem 'nokogiri', '=1.5.0'
 
 group :test do

--- a/lib/vast/version.rb
+++ b/lib/vast/version.rb
@@ -1,0 +1,3 @@
+module Vast
+  VERSION = '1.0.4'
+end

--- a/vast.gemspec
+++ b/vast.gemspec
@@ -2,9 +2,11 @@
 lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
 
+require 'vast/version'
+
 Gem::Specification.new do |s|
   s.name        = "vast"
-  s.version     = "1.0.4"
+  s.version     = Vast::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Chris Dinn"]
   s.email       = ["chrisgdinn@gmail.com"]
@@ -12,9 +14,13 @@ Gem::Specification.new do |s|
   s.summary     = "A gem for working with VAST 2.0 documents"
   s.license     = "MIT"
 
-  s.files       = Dir['lib/*.rb'] + Dir['lib/*.xsd'] + Dir['lib/vast/*.rb'] + Dir['test/*.rb'] + Dir['test/examples/*.xml'] + %w(LICENSE README.rdoc)
+  s.files       = Dir.glob('lib/**/*') + %w(LICENSE README.rdoc CHANGELOG.md)
+  s.require_path = 'lib'
 
   s.add_dependency 'nokogiri', '~> 1.5'
 
-  s.require_path = 'lib'
+  s.add_development_dependency 'gem-release'
+  s.add_development_dependency 'pathological'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
- Add CHANGELOG.md to track all major changes between releases.
- Move development dependencies into gemspec
- Add dev dependency on gem-release to handle versioning, tagging & pushing released artifacts.
- Add Travis CI status image to README.rdoc
- Update README for VAST 3.0 support
- Document Formal release process
- Move versioning from gemspec to lib/vast/version.rb