### PR TITLE
Add code climate reporting for style and coverage

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,48 @@
+---
+version: "2"
+checks:
+  argument-count:
+    config:
+      threshold: 4
+  complex-logic:
+    config:
+      threshold: 4
+  file-lines:
+    config:
+      threshold: 250
+  method-complexity:
+    config:
+      threshold: 5
+  method-count:
+    config:
+      threshold: 20
+  method-lines:
+    config:
+      threshold: 25
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 4
+  # code climate uses a language-specific threshold for simalar and
+  # identical code.The overrides below affects all languages. The
+  # value 18 lines is the default threshold for Ruby.
+  similar-code:
+    config:
+      threshold: 18
+  identical-code:
+    config:
+      threshold: 18
+plugins:
+  flog:
+    enabled: true
+    config:
+      score_threshold: 20.0
+  git-legal:
+    enabled: true
+  reek:
+    enabled: true
+  rubocop:
+    enabled: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 dist: trusty
 language: ruby
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script: bundle exec rake
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 matrix:
   include:
     - rvm: 2.6.3

--- a/test/extension_test.rb
+++ b/test/extension_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ExtensionTest < Test::Unit::TestCase
   
-  def test_should_know_attributes
+  def test_should_know_attributes_type
     document_file = example_file('document_with_one_inline_ad.xml')
     document = VAST::Document.parse!(document_file)
     extension = VAST::Extension.new(document.at('Extension'))
@@ -10,7 +10,7 @@ class ExtensionTest < Test::Unit::TestCase
     assert_equal "DART", extension.type
   end
   
-  def test_should_know_attributes
+  def test_should_know_attributes_xml
     document_file = example_file('document_with_one_inline_ad.xml')
     document = VAST::Document.parse!(document_file)
     extension = VAST::Extension.new(document.at('Extension'))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'test/unit'
 require 'rubygems'
 require 'bundler'

--- a/vast.gemspec
+++ b/vast.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'gem-release'
   s.add_development_dependency 'pathological'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
Add Code Climate for reporting code quality of pull requests to the vast project. Code Climate is free to use for public open-source projects.

@chrisdinn this will require you to set up a code climate account. The following are instructions for setting up code climate. This setup must be completed before merging this pull request.

I recommend signing up to Code Climate using your GitHub account. This will make setup easier. You won't have to link your code climate, and Github accounts later.
https://codeclimate.com/login/github/join

Add the vast repo to code climate. Open Source Repos are free in Code Climate.
https://codeclimate.com/github/repos/new

From https://codeclimate.com/github/chrisdinn/vast
Go to Repo Settings -> GitHub
Turn on Summary comments and/or Inline issue comments
Install Webhook on GitHub

From https://codeclimate.com/github/chrisdinn/vast
Go to Repo Settings -> Test coverage
Copy the <TEST REPORTER ID>
Go to https://travis-ci.org/chrisdinn/vast/settings
Under Environment Variables insert
NAME: CC_TEST_REPORTER_ID
VALUE: <TEST REPORTER ID>
BRANCH: All branches
Display value in build logs should be off
Click Add

**Optional:**
From https://codeclimate.com/github/chrisdinn/vast
Repo Settings -> Badges
Select the Test Coverage Badge RDOC format
Copy the text and add it to the end of the first line in README.rdoc file
Only you can do this because the URL to the badge has a unique id for the repo that only you as the git repo owner can see in the code climate web console.